### PR TITLE
🔥 Hotfix : 메인 페이지 api 보내주는 값 변경

### DIFF
--- a/src/components/main/Main.jsx
+++ b/src/components/main/Main.jsx
@@ -135,7 +135,7 @@ const Main = () => {
         </Styled.BestUserWrap>
       ) : (
         <Styled.BestUserWrap>
-          {hallOfFame.data.map((data, index) => (
+          {hallOfFame.data.content.map((data, index) => (
             <BestUser
               key={"BestUser" + index}
               number={index + 1}


### PR DESCRIPTION
1. api 에서 오는 데이터를 content 로 감싸서 보내서 map 그리는데 에러 발생으로, 배포 메인 페이지 죽어서 변경해서 다시 올립니다.